### PR TITLE
Fix to handle contribution without recur record not present incivi

### DIFF
--- a/CRM/Core/Payment/SmartDebitIPN.php
+++ b/CRM/Core/Payment/SmartDebitIPN.php
@@ -401,7 +401,7 @@ EOF;
                                                       , 'name'
                                                       );
 
-    if ( !$this->validateData( $input, $ids, $objects, TRUE, $paymentProcessorID ) ) {
+    if ( !$this->validateData( $input, $ids, $objects, FALSE, $paymentProcessorID ) ) {
       return FALSE;
     }
 

--- a/templates/CRM/DirectDebit/Form/Sync.tpl
+++ b/templates/CRM/DirectDebit/Form/Sync.tpl
@@ -7,6 +7,8 @@
       <tr><td>{ts}New Direct Debit{/ts}:</td><td>{$stats.New}</td></tr>
       <tr><td>{ts}Cancelled Direct Debit{/ts}:</td><td>{$stats.Canceled}</td></tr>
       <tr><td>{ts}Failed Direct Debit{/ts}:</td><td>{$stats.Failed}</td></tr>
+      <tr><td>{ts}Not Handled smart debit record{/ts}:</td><td>{$stats.Not_Handled}&nbsp; (not found in civiCRM)</td></tr>
+      <tr><td>{ts}Live Direct Debit And Matching record found in civiCRM{/ts}:</td><td>{$stats.Live}</td></tr>
       <tr colspan=2><td>{ts}Total{/ts}:</td><td>{$stats.Total}</td></tr>
       </table>
     </div>


### PR DESCRIPTION
1) FIx contributions with no recur record present in civiCrm
2) FIx the sync to work if the smart debit record has payee reference as contact id
3) Fix the sync to handle when no contribution present in civiCrm for the contact, but the contact id is available in smart debit API
