### PR TITLE
Feature: Offline Direct Debit Setup For Membership and Contribution

### DIFF
--- a/CRM/DirectDebit/Form/Newdd.php
+++ b/CRM/DirectDebit/Form/Newdd.php
@@ -1,0 +1,242 @@
+<?php
+
+class CRM_DirectDebit_Form_Newdd extends CRM_Core_Form {
+  
+  public $_contactID;
+  
+  public $_paymentProcessor = array();
+  
+  public $_id;
+  
+  public $_action;
+  
+  public $_paymentFields = array();
+  
+  public $_fields = array();
+  
+  public $_bltID = 5;
+  
+  public function preProcess() {
+    // Check permission for action.
+    if (!CRM_Core_Permission::checkActionPermission('CiviContribute', CRM_Core_Action::ADD)) {
+      CRM_Core_Error::fatal(ts('You do not have permission to access this page.'));
+    }  
+    // Get the contact id
+    $this->_contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE);
+    // Get the action.
+    $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'add');  
+    // Get the membership id
+    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);    
+    // Get the smart debit payment processor details
+    $this->_paymentProcessor = self::getSmartDebitDetails();
+   
+  }
+  
+  public function buildQuickForm() {
+    $totalAmount = $this->addMoney('amount', ts('Amount'), CRM_Core_DAO::getAttribute('CRM_Contribute_DAO_Contribution', 'total_amount'), TRUE, 'currency', NULL);
+    $this->add('text', "email-{$this->_bltID}", ts('Email Address'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_Email', 'email'), TRUE );
+    $this->addRule("email-{$this->_bltID}", ts('Email is not valid.'), 'email');  
+    
+    $submitButton = array(
+      array('type' => 'upload',
+        'name' => ts('Confirm Direct Debit'),
+        'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
+        'isDefault' => TRUE,),
+      array('type' => 'cancel',
+      'name' => ts('Cancel'),)
+    );
+   
+    require_once 'UK_Direct_Debit/Form/Main.php';
+    $ddForm = new UK_Direct_Debit_Form_Main();
+    $ddForm->buildOfflineDirectDebit( $this );
+    $defaults['ddi_reference'] = $ddForm::getDDIReference();
+    $this->setDefaults($defaults);
+    $this->assign('bltID', $this->_bltID);
+    
+    $this->addFormRule(array('CRM_DirectDebit_Form_Newdd', 'formRule'), $this);
+    $this->addButtons($submitButton);
+
+  }
+  
+  public function setDefaultValues() {
+    $defaults			      = array();
+    $contactDetails		      = self::getContactDetails($this->_id);
+    $defaults['email-'.$this->_bltID] = $contactDetails['email'];
+    $defaults['amount']		      = $contactDetails['amount'];
+    return $defaults;
+  }
+  
+  public static function formRule($fields, $files, $self) {
+    $errors = array ();      
+    require_once self::getSmartDebitPaymentPath();
+    $validateOutput = uk_co_vedaconsulting_payment_smartdebitdd::validatePayment($fields, $files, $self);
+    if ($validateOutput['is_error'] == 1) {
+      $errors['_qf_default'] = $validateOutput['error_message'];
+    }
+    return $errors ? $errors : TRUE;      
+  }
+  
+  function postProcess() {
+    $params		  = $this->controller->exportValues($this->_name);
+    $params['contactID']  = $this->_contactID;
+    
+    require_once self::getSmartDebitPaymentPath();      
+    $smartDebitResponse	  = uk_co_vedaconsulting_payment_smartdebitdd:: doDirectPayment($params);
+    $start_date		  = $smartDebitResponse['start_date'];
+    $trxn_id		  = $smartDebitResponse['trxn_id'];
+    $contributionDetails  = self::getContactDetails($this->_id);
+    $contributionID	  = $contributionDetails['contribution_id'];
+    $invoiceID		  = $contributionDetails['invoice_id'];
+    $financial_type_id    = $contributionDetails['financial_type_id'];
+    $contributionRecurID  = $contributionDetails['contribution_recur_id'];
+    $isRecur		  = 1;
+    
+    if(empty($contributionRecurID)) {
+      // Build recur params
+      $recurParams = array(
+	'contact_id'		=>  $this->_contactID,
+	'create_date'		=>  date('YmdHis'),
+	'modified_date'		=>  date('YmdHis'),
+	'start_date'		=>  $start_date,
+	'amount'		=>  $params['amount'],
+	'frequency_unit'	=>  self::translateSmartDebitFrequencyUnit($smartDebitResponse['frequency_type']),
+	'frequency_interval'	=>  1,
+	'payment_processor_id'	=>  $this->_paymentProcessor['id'],
+	'contribution_status_id'=>  CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'In Progress'),
+	'trxn_id'		=>  $trxn_id,
+	'invoice_id'		=>  $invoiceID,
+	'financial_type_id'	=>  $financial_type_id,
+      );
+
+      $recurring		  = CRM_Contribute_BAO_ContributionRecur::add($recurParams);
+      $contributionRecurID	  = $recurring->id;      
+      
+      CRM_Core_DAO::executeQuery('UPDATE civicrm_membership SET contribution_recur_id = %1 WHERE id = %2', array(1=>array($contributionRecurID, 'Int'), 2=>array($this->_id, 'Int')));
+      
+    }
+    
+    $paymentProcessorType = urlencode( 'Smart Debit' );
+    $paymentType	  = urlencode( $this->_paymentProcessor['payment_type']);
+    $membershipID         = urlencode( $this->_id );
+    $contactID            = urlencode( $this->_contactID );
+    $invoiceID            = urlencode( $invoiceID );
+    $amount               = urlencode( $params['amount'] );
+    $trxn_id              = urlencode( $trxn_id );
+    $collection_day       = urlencode( $params['preferred_collection_day'] );
+
+    CRM_Core_Error::debug_log_message( 'paymentProcessorType='.$paymentProcessorType);
+    CRM_Core_Error::debug_log_message( 'paymentType='.$paymentType);
+    CRM_Core_Error::debug_log_message( 'membershipID='.$membershipID);
+    CRM_Core_Error::debug_log_message( 'contributionID='.$contributionID);
+    CRM_Core_Error::debug_log_message( 'contactID='.$contactID);
+    CRM_Core_Error::debug_log_message( 'invoiceID='.$invoiceID);
+    CRM_Core_Error::debug_log_message( 'amount='.$amount);
+    CRM_Core_Error::debug_log_message( 'isRecur='.$isRecur);
+    CRM_Core_Error::debug_log_message( 'trxn_id='.$trxn_id);
+    CRM_Core_Error::debug_log_message( 'start_date='.$start_date);
+    CRM_Core_Error::debug_log_message( 'collection_day='.$collection_day);
+    CRM_Core_Error::debug_log_message( 'contributionRecurID:' .$contributionRecurID );
+    CRM_Core_Error::debug_log_message( 'CIVICRM_UF_BASEURL='.CIVICRM_UF_BASEURL);
+
+    $query = "processor_name=".$paymentProcessorType."&module=contribute&contactID=".$contactID."&contributionID=".$contributionID."&membershipID=".$membershipID."&invoice=".$invoiceID."&mc_gross=".$amount."&payment_status=Completed&txn_type=recurring_payment&contributionRecurID=$contributionRecurID&txn_id=$trxn_id&first_collection_date=$start_date&collection_day=$collection_day";
+
+    CRM_Core_Error:: debug_log_message( 'uk_direct_debit_civicrm_postProcess query = '.$query);
+
+    // Get the recur ID for the contribution
+    $url = CRM_Utils_System::url('civicrm/payment/ipn', $query,  TRUE, NULL, FALSE, TRUE);
+    CRM_Core_Error::debug_log_message('uk_direct_debit_civicrm_postProcess url='.$url);
+    call_CiviCRM_IPN($url);
+    
+  }
+  
+
+  static function translateSmartDebitFrequencyUnit($smartDebitFrequency) {
+    if ($smartDebitFrequency == 'Q') {
+      return('month' );
+    }
+    if ($smartDebitFrequency == 'Y') {
+      return('year' );
+    }
+    return('month' );
+  }
+    
+  static function getSmartDebitDetails(){
+    $paymentProcessorType   = CRM_Core_PseudoConstant::paymentProcessorType(false, null, 'name');
+    $paymentProcessorTypeId = CRM_Utils_Array::key('Smart Debit', $paymentProcessorType);
+    $domainID               = CRM_Core_Config::domainID();
+
+    if(empty($paymentProcessorTypeId)) {
+      CRM_Core_Session::setStatus(ts('Make sure Payment Processor Type (Smart Debit) is set in Payment Processor setting'), Error, 'error');
+      return FALSE;
+    }
+
+    $sql  = " SELECT user_name ";
+    $sql .= " ,      password ";
+    $sql .= " ,      signature ";
+    $sql .= " ,      billing_mode ";
+    $sql .= " ,      payment_type ";
+    $sql .= " ,      url_api ";
+    $sql .= " ,      id ";
+    $sql .= " FROM civicrm_payment_processor ";
+    $sql .= " WHERE payment_processor_type_id = %1 ";
+    $sql .= " AND is_test= %2 AND domain_id = %3";
+
+    $params = array( 1 => array( $paymentProcessorTypeId, 'Integer' )
+                   , 2 => array( '0', 'Int' )
+                   , 3 => array( $domainID, 'Int' )
+                   );
+
+    $dao    = CRM_Core_DAO::executeQuery( $sql, $params);
+    $result = array();
+    if ($dao->fetch()) {
+      if(empty($dao->user_name) || empty($dao->password) || empty($dao->signature)) {
+        CRM_Core_Session::setStatus(ts('Smart Debit API User Details Missing, Please check the Smart Debit Payment Processor is configured Properly'), Error, 'error');
+        return FALSE;
+      }
+      $result   = array(
+        'user_name'	  => $dao->user_name,
+        'password'	  => $dao->password,
+        'signature'	  => $dao->signature,
+        'billing_mode'    => $dao->billing_mode,
+        'payment_type'    => $dao->payment_type,
+        'url_api'	  => $dao->url_api,
+        'id'		  => $dao->id,
+      );
+
+    }
+    return $result;
+
+  }//end function
+    
+  static function getSmartDebitPaymentPath() {
+    $config   = CRM_Core_Config::singleton();
+    $extenDr  = $config->extensionsDir;
+    return $extenDr . DIRECTORY_SEPARATOR .'uk.co.vedaconsulting.payment.smartdebitdd' .DIRECTORY_SEPARATOR.'smart_debit_dd.php';
+  }
+  
+  static function getContactDetails($membershipID) {
+    if (empty($membershipID)) {
+      return;
+    }
+    $query = "
+      SELECT cc.id, cc.invoice_id, cc.financial_type_id, ce.email, cc.total_amount, cm.contribution_recur_id
+      FROM civicrm_contribution cc 
+      INNER JOIN civicrm_membership_payment cmp ON cmp.contribution_id = cc.id
+      INNER JOIN civicrm_membership cm ON cm.id = cmp.membership_id
+      INNER JOIN civicrm_email ce ON (ce.contact_id = cc.contact_id AND ce.is_primary = 1)
+      WHERE cmp.membership_id = %1";
+    $dao = CRM_Core_DAO::executeQuery($query, array(1 => array($membershipID, 'Int')));
+    $contactDetails = array();
+    if ($dao->fetch()) {
+      $contactDetails['contribution_id']	= $dao->id;
+      $contactDetails['amount']			= $dao->total_amount;
+      $contactDetails['invoice_id']		= $dao->invoice_id;
+      $contactDetails['financial_type_id']	= $dao->financial_type_id;
+      $contactDetails['email']			= $dao->email;
+      $contactDetails['contribution_recur_id']  = $dao->contribution_recur_id;
+    }
+    return $contactDetails;
+  }
+}
+
+

--- a/CRM/DirectDebit/Form/Newdonation.php
+++ b/CRM/DirectDebit/Form/Newdonation.php
@@ -1,6 +1,6 @@
 <?php
 
-class CRM_DirectDebit_Form_Newdd extends CRM_Core_Form {
+class CRM_DirectDebit_Form_Newdonation extends CRM_Core_Form {
   
   public $_contactID;
   
@@ -25,21 +25,28 @@ class CRM_DirectDebit_Form_Newdd extends CRM_Core_Form {
     $this->_contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE);
     // Get the action.
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'add');  
-    // Get the membership id
-    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);    
+    
     // Get the smart debit payment processor details
     $this->_paymentProcessor = self::getSmartDebitDetails();
    
   }
   
   public function buildQuickForm() {
-    // Membership amount
     $totalAmount = $this->addMoney('amount', ts('Amount'), CRM_Core_DAO::getAttribute('CRM_Contribute_DAO_Contribution', 'total_amount'), TRUE, 'currency', NULL);
     $this->add('text', "email-{$this->_bltID}", ts('Email Address'), CRM_Core_DAO::getAttribute('CRM_Core_DAO_Email', 'email'), TRUE );
     $this->addRule("email-{$this->_bltID}", ts('Email is not valid.'), 'email');  
-    // Membership Frequench Month/Year
-    $this->add('hidden', 'frequency_unit');
+    $frequencyUnit = $this->add('select', 'frequency_unit',
+      ts('Frequency Unit'),
+      array('' => ts('- select -')) + CRM_Core_OptionGroup::values('recur_frequency_units', FALSE, FALSE, FALSE, NULL, 'name'),
+      TRUE, NULL
+    );
     
+    $financialType = $this->add('select', 'financial_type_id',
+      ts('Financial Type'),
+      array('' => ts('- select -')) + CRM_Contribute_PseudoConstant::financialType(),
+      TRUE
+    );
+        
     $submitButton = array(
       array('type' => 'upload',
         'name' => ts('Confirm Direct Debit'),
@@ -49,27 +56,22 @@ class CRM_DirectDebit_Form_Newdd extends CRM_Core_Form {
       'name' => ts('Cancel'),)
     );
    
-    // Build Direct Debit Payment Fields including Billing
     require_once 'UK_Direct_Debit/Form/Main.php';
     $ddForm = new UK_Direct_Debit_Form_Main();
     $ddForm->buildOfflineDirectDebit( $this );
-    // Required for validation
     $defaults['ddi_reference'] = $ddForm::getDDIReference();
     $this->setDefaults($defaults);
-    // Required for billing blocks to be displayed
-    $this->assign('bltID', $this->_bltID);    
+    $this->assign('bltID', $this->_bltID);
     
-    $this->addFormRule(array('CRM_DirectDebit_Form_Newdd', 'formRule'), $this);
+    $this->addFormRule(array('CRM_DirectDebit_Form_Newdonation', 'formRule'), $this);
     $this->addButtons($submitButton);
 
   }
   
   public function setDefaultValues() {
     $defaults			      = array();
-    $contactDetails		      = self::getContactDetails($this->_id);
-    $defaults['email-'.$this->_bltID] = $contactDetails['email'];
-    $defaults['amount']		      = $contactDetails['amount'];
-    $defaults['frequency_unit']	      = $contactDetails['frequency_unit'];
+    list($displayName, $email)	      = CRM_Contact_BAO_Contact_Location::getEmailDetails($this->_contactID);
+    $defaults['email-'.$this->_bltID] = $email;
     return $defaults;
   }
   
@@ -88,17 +90,11 @@ class CRM_DirectDebit_Form_Newdd extends CRM_Core_Form {
     $params['contactID']  = $this->_contactID;
     
     require_once self::getSmartDebitPaymentPath();      
-    $smartDebitResponse	  = uk_co_vedaconsulting_payment_smartdebitdd:: doDirectPayment($params);
+    $smartDebitResponse	  = uk_co_vedaconsulting_payment_smartdebitdd:: doDirectPayment($params);    
     $start_date		  = date('Y-m-d', strtotime($smartDebitResponse['start_date']));
     $trxn_id		  = $smartDebitResponse['trxn_id'];
-    $contributionDetails  = self::getContactDetails($this->_id);
-    $contributionID	  = $contributionDetails['contribution_id'];
-    $invoiceID		  = $contributionDetails['invoice_id'];
-    $financial_type_id    = $contributionDetails['financial_type_id'];
-    $contributionRecurID  = $contributionDetails['contribution_recur_id'];
-    $isRecur		  = 1;
+    list($y, $m, $d)	  = explode('-', $smartDebitResponse['start_date']);
     
-    if(empty($contributionRecurID)) {
       // Build recur params
       $recurParams = array(
 	'contact_id'		=>  $this->_contactID,
@@ -111,52 +107,16 @@ class CRM_DirectDebit_Form_Newdd extends CRM_Core_Form {
 	'payment_processor_id'	=>  $this->_paymentProcessor['id'],
 	'contribution_status_id'=>  CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'In Progress'),
 	'trxn_id'		=>  $trxn_id,
-	'invoice_id'		=>  $invoiceID,
-	'financial_type_id'	=>  $financial_type_id,
+	'financial_type_id'	=>  $params['financial_type_id'],
 	'auto_renew'		=> '1', // Make auto renew
-	'processor_id'          =>  $trxn_id,
-	'payment_instrument_id' => UK_Direct_Debit_Form_Main::getDDPaymentInstrumentID(),//Direct Debit
+	'cycle_day'		=> $d,
+	'currency'		=> 'GBP',//Smart Debit supports UK currency
+	'processor_id'          => $trxn_id,
+	'payment_instrument_id' => UK_Direct_Debit_Form_Main::getDDPaymentInstrumentID(),
       );
 
-      $recurring		  = CRM_Contribute_BAO_ContributionRecur::add($recurParams);
-      $contributionRecurID	  = $recurring->id;      
-      // Update Membership column in recurring table
-      CRM_Core_DAO::executeQuery('UPDATE civicrm_membership SET contribution_recur_id = %1 WHERE id = %2', array(1=>array($contributionRecurID, 'Int'), 2=>array($this->_id, 'Int')));
+      $recurring		 = CRM_Contribute_BAO_ContributionRecur::add($recurParams);
       
-    }
-    
-    $paymentProcessorType = urlencode( 'Smart Debit' );
-    $paymentType	  = urlencode( $this->_paymentProcessor['payment_type']);
-    $membershipID         = urlencode( $this->_id );
-    $contactID            = urlencode( $this->_contactID );
-    $invoiceID            = urlencode( $invoiceID );
-    $amount               = urlencode( $params['amount'] );
-    $trxn_id              = urlencode( $trxn_id );
-    $collection_day       = urlencode( $params['preferred_collection_day'] );
-
-    CRM_Core_Error::debug_log_message( 'paymentProcessorType='.$paymentProcessorType);
-    CRM_Core_Error::debug_log_message( 'paymentType='.$paymentType);
-    CRM_Core_Error::debug_log_message( 'membershipID='.$membershipID);
-    CRM_Core_Error::debug_log_message( 'contributionID='.$contributionID);
-    CRM_Core_Error::debug_log_message( 'contactID='.$contactID);
-    CRM_Core_Error::debug_log_message( 'invoiceID='.$invoiceID);
-    CRM_Core_Error::debug_log_message( 'amount='.$amount);
-    CRM_Core_Error::debug_log_message( 'isRecur='.$isRecur);
-    CRM_Core_Error::debug_log_message( 'trxn_id='.$trxn_id);
-    CRM_Core_Error::debug_log_message( 'start_date='.$start_date);
-    CRM_Core_Error::debug_log_message( 'collection_day='.$collection_day);
-    CRM_Core_Error::debug_log_message( 'contributionRecurID:' .$contributionRecurID );
-    CRM_Core_Error::debug_log_message( 'CIVICRM_UF_BASEURL='.CIVICRM_UF_BASEURL);
-
-    $query = "processor_name=".$paymentProcessorType."&module=contribute&contactID=".$contactID."&contributionID=".$contributionID."&membershipID=".$membershipID."&invoice=".$invoiceID."&mc_gross=".$amount."&payment_status=Completed&txn_type=recurring_payment&contributionRecurID=$contributionRecurID&txn_id=$trxn_id&first_collection_date=$start_date&collection_day=$collection_day";
-
-    CRM_Core_Error:: debug_log_message( 'uk_direct_debit_civicrm_postProcess query = '.$query);
-
-    // Get the recur ID for the contribution
-    $url = CRM_Utils_System::url('civicrm/payment/ipn', $query,  TRUE, NULL, FALSE, TRUE);
-    CRM_Core_Error::debug_log_message('uk_direct_debit_civicrm_postProcess url='.$url);
-    call_CiviCRM_IPN($url);
-    
   }
   
 
@@ -224,31 +184,6 @@ class CRM_DirectDebit_Form_Newdd extends CRM_Core_Form {
     return $extenDr . DIRECTORY_SEPARATOR .'uk.co.vedaconsulting.payment.smartdebitdd' .DIRECTORY_SEPARATOR.'smart_debit_dd.php';
   }
   
-  static function getContactDetails($membershipID) {
-    if (empty($membershipID)) {
-      return;
-    }
-    $query = "
-      SELECT cc.id, cc.invoice_id, cc.financial_type_id, ce.email, cc.total_amount, cm.contribution_recur_id, cmt.duration_unit
-      FROM civicrm_contribution cc 
-      INNER JOIN civicrm_membership_payment cmp ON cmp.contribution_id = cc.id
-      INNER JOIN civicrm_membership cm ON cm.id = cmp.membership_id
-      INNER JOIN civicrm_membership_type cmt ON cmt.id = cm.membership_type_id
-      INNER JOIN civicrm_email ce ON (ce.contact_id = cc.contact_id AND ce.is_primary = 1)
-      WHERE cmp.membership_id = %1";
-    $dao = CRM_Core_DAO::executeQuery($query, array(1 => array($membershipID, 'Int')));
-    $contactDetails = array();
-    if ($dao->fetch()) {
-      $contactDetails['contribution_id']	= $dao->id;
-      $contactDetails['amount']			= $dao->total_amount;
-      $contactDetails['invoice_id']		= $dao->invoice_id;
-      $contactDetails['financial_type_id']	= $dao->financial_type_id;
-      $contactDetails['email']			= $dao->email;
-      $contactDetails['contribution_recur_id']  = $dao->contribution_recur_id;
-      $contactDetails['frequency_unit']		= $dao->duration_unit;
-    }
-    return $contactDetails;
-  }
 }
 
 

--- a/CRM/DirectDebit/Form/SyncSd.php
+++ b/CRM/DirectDebit/Form/SyncSd.php
@@ -224,7 +224,7 @@ class CRM_DirectDebit_Form_SyncSd extends CRM_Core_Form {
     $url = "https://secure.ddprocessing.co.uk/api/data/dump?query[service_user][pslid]=$pslid&query[report_format]=XML";
     // Restrict to a single payer if we have a reference
     if ($referenceNumber) {
-      $url .= "&query[reference_number]=$referenceNumber";
+      $url .= "&query[reference_number]=".rawurlencode($referenceNumber);
     }
 
     $response = self::requestPost( $url, $username, $password );

--- a/UK_Direct_Debit/Form/Main.php
+++ b/UK_Direct_Debit/Form/Main.php
@@ -795,5 +795,123 @@ EOF;
         }
       }
   }
+  
+  
+  function buildOfflineDirectDebit(&$form, $useRequired = FALSE) {
+    if ( $form->_paymentProcessor['billing_mode'] & CRM_Core_Payment::BILLING_MODE_FORM ) {
+      self::setDirectDebitFields( $form );
+      self::setBillingDetailsFields($form);
+      foreach ( $form->_paymentFields as $name => $field ) {
+        if ( isset($field['cc_field'] ) &&
+          $field['cc_field']
+        ) {
+          if ($field['htmlType'] == 'chainSelect') {
+            $form->addChainSelect($field['name'], array('required' => $useRequired && $field['is_required']));
+          }
+          else {
+            $form->add( $field['htmlType'],
+                        $field['name'],
+                        $field['title'],
+                        CRM_Utils_Array::value('attributes', $field),
+                        $useRequired ? $field['is_required'] : FALSE
+                      );
+          }
+        }
+      }
+
+      $form->addRule( 'bank_identification_number',
+                      ts( 'Please enter a valid Bank Identification Number (value must not contain punctuation characters).' ),
+                      'nopunctuation'
+                    );
+
+      $form->addRule( 'bank_account_number',
+                      ts( 'Please enter a valid Bank Account Number (value must not contain punctuation characters).' ),
+                      'nopunctuation'
+                    );
+    }  
+    
+  }
+  
+  function setBillingDetailsFields(&$form) {
+    $bltID =  $form->_bltID;
+    $form->_paymentFields['billing_first_name'] = array(
+      'htmlType' => 'text',
+      'name' => 'billing_first_name',
+      'title' => ts('Billing First Name'),
+      'cc_field' => TRUE,
+      'attributes' => array('size' => 30, 'maxlength' => 60, 'autocomplete' => 'off'),
+      'is_required' => TRUE,
+    );
+
+    $form->_paymentFields['billing_middle_name'] = array(
+      'htmlType' => 'text',
+      'name' => 'billing_middle_name',
+      'title' => ts('Billing Middle Name'),
+      'cc_field' => TRUE,
+      'attributes' => array('size' => 30, 'maxlength' => 60, 'autocomplete' => 'off'),
+      'is_required' => FALSE,
+    );
+
+    $form->_paymentFields['billing_last_name'] = array(
+      'htmlType' => 'text',
+      'name' => 'billing_last_name',
+      'title' => ts('Billing Last Name'),
+      'cc_field' => TRUE,
+      'attributes' => array('size' => 30, 'maxlength' => 60, 'autocomplete' => 'off'),
+      'is_required' => TRUE,
+    );
+
+    $form->_paymentFields["billing_street_address-{$bltID}"] = array(
+      'htmlType' => 'text',
+      'name' => "billing_street_address-{$bltID}",
+      'title' => ts('Street Address'),
+      'cc_field' => TRUE,
+      'attributes' => array('size' => 30, 'maxlength' => 60, 'autocomplete' => 'off'),
+      'is_required' => TRUE,
+    );
+
+    $form->_paymentFields["billing_city-{$bltID}"] = array(
+      'htmlType' => 'text',
+      'name' => "billing_city-{$bltID}",
+      'title' => ts('City'),
+      'cc_field' => TRUE,
+      'attributes' => array('size' => 30, 'maxlength' => 60, 'autocomplete' => 'off'),
+      'is_required' => TRUE,
+    );
+
+    $form->_paymentFields["billing_state_province_id-{$bltID}"] = array(
+      'htmlType' => 'select',
+      'title' => ts('State/Province'),
+      'name' => "billing_state_province_id-{$bltID}",
+      'cc_field' => TRUE,
+	  'attributes' => array(
+        '' => ts('- select -'),
+      ) +
+      CRM_Core_PseudoConstant::stateProvince(),
+      'is_required' => TRUE,
+    );
+
+    $form->_paymentFields["billing_postal_code-{$bltID}"] = array(
+      'htmlType' => 'text',
+      'name' => "billing_postal_code-{$bltID}",
+      'title' => ts('Postal Code'),
+      'cc_field' => TRUE,
+      'attributes' => array('size' => 30, 'maxlength' => 60, 'autocomplete' => 'off'),
+      'is_required' => TRUE,
+    );
+
+    $form->_paymentFields["billing_country_id-{$bltID}"] = array(
+      'htmlType' => 'select',
+      'name' => "billing_country_id-{$bltID}",
+      'title' => ts('Country'),
+      'cc_field' => TRUE,
+      'attributes' => array(
+        '' => ts('- select -'),
+      ) +
+      CRM_Core_PseudoConstant::country(),
+      'is_required' => TRUE,
+    );
+   
+  }
 
 }

--- a/UK_Direct_Debit/Form/Main.php
+++ b/UK_Direct_Debit/Form/Main.php
@@ -133,12 +133,18 @@ class UK_Direct_Debit_Form_Main extends CRM_Core_Form
     $companyAddress['company_name'] = $domain->name;
     if (!empty($domainLoc['address'])) {
       $companyAddress['address1']     = $domainLoc['address'][1]['street_address'];
-      $companyAddress['address2']     = $domainLoc['address'][1]['supplemental_address_1'];
-      $companyAddress['address3']     = $domainLoc['address'][1]['supplemental_address_2'];
+      if (array_key_exists('supplemental_address_1', $domainLoc['address'][1])) {
+	$companyAddress['address2']     = $domainLoc['address'][1]['supplemental_address_1'];
+      }
+      if (array_key_exists('supplemental_address_2', $domainLoc['address'][1])) {
+	$companyAddress['address3']     = $domainLoc['address'][1]['supplemental_address_2'];
+      }
       $companyAddress['town']         = $domainLoc['address'][1]['city'];
       $companyAddress['postcode']     = $domainLoc['address'][1]['postal_code'];
-      $companyAddress['county']       = CRM_Core_PseudoConstant::county($domainLoc['address'][1]['county_id']);
-      $companyAddress['country_id']   = CRM_Core_PseudoConstant::country($domainLoc['address'][1]['country_id']);
+      if (array_key_exists('county_id', $domainLoc['address'][1])) {
+	$companyAddress['county']       = CRM_Core_PseudoConstant::county($domainLoc['address'][1]['county_id']);
+      }
+      $companyAddress['country_id']   = CRM_Core_PseudoConstant::country($domainLoc['address'][1]['country_id']);	
     }
 
     return $companyAddress;

--- a/info.xml
+++ b/info.xml
@@ -16,8 +16,8 @@
     <url desc="Licensing"></url>
   </urls>
   <license>AGPL</license>
-  <releaseDate>2015-07-13</releaseDate>
-  <version>2.2</version>
+  <releaseDate>2015-10-09</releaseDate>
+  <version>2.3</version>
   <develStage>stable</develStage>
   <compatibility><ver>4.6</ver></compatibility>
   <comments></comments>

--- a/templates/CRM/Contribute/Form/UpdateBilling.tpl
+++ b/templates/CRM/Contribute/Form/UpdateBilling.tpl
@@ -1,0 +1,106 @@
+<!-- Customised Civi File .tpl file invoked: ukdirectdebit/templates/CRM/Contribute/Form/UpdateBilling.tpl. Call via form.tpl if we have a form in the page. -->
+{*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.6                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2015                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*}
+
+<div id="help">
+  <div class="icon inform-icon"></div>&nbsp;
+  {if $mode eq 'auto_renew'}
+      {ts}Use this form to update the credit card and billing name and address used with the auto-renewal option for your {$membershipType} membership.{/ts}
+  {else}
+    <strong>{ts 1=$amount|crmMoney 2=$frequency_interval 3=$frequency_unit}Recurring Contribution Details: %1 every %2 %3{/ts}
+    {if $installments}
+      {ts 1=$installments}for %1 installments{/ts}.
+    {/if}</strong>
+    {if $paymentProcessor.payment_processor_type eq 'Smart Debit'}
+      <div class="content">{ts}Use this form to update the direct debit billing name and address used for this recurring contribution.{/ts}</div>
+    {else}
+      <div class="content">{ts}Use this form to update the credit card and billing name and address used for this recurring contribution.{/ts}</div>
+    {/if}
+  {/if}
+</div>
+{if $paymentProcessor.payment_processor_type eq 'Smart Debit'}
+  <div class="crm-block crm-form-block crm-contribution-form-block">
+    <fieldset class="billing_name_address-group">
+    <legend>{ts}Billing Name and Address{/ts}</legend>
+    <div class="crm-section billing_name_address-section">
+	<div class="crm-section billingNameInfo-section">
+	  <div class="content description">
+	       {ts}Enter the name of the account holder, and the corresponding billing address.{/ts}
+	  </div>
+	</div>
+	<div class="crm-section {$form.billing_first_name.name}-section">
+	  <div class="label">{$form.billing_first_name.label}</div>
+	  <div class="content">{$form.billing_first_name.html}</div>
+	  <div class="clear"></div>
+	</div>
+	<div class="crm-section {$form.billing_middle_name.name}-section">
+	  <div class="label">{$form.billing_middle_name.label}</div>
+	  <div class="content">{$form.billing_middle_name.html}</div>
+	  <div class="clear"></div>
+	</div>
+	<div class="crm-section {$form.billing_last_name.name}-section">
+	  <div class="label">{$form.billing_last_name.label}</div>
+	  <div class="content">{$form.billing_last_name.html}</div>
+	  <div class="clear"></div>
+	</div>
+	{assign var=n value=billing_street_address-$bltID}
+	<div class="crm-section {$form.$n.name}-section">
+	  <div class="label">{$form.$n.label}</div>
+	  <div class="content">{$form.$n.html}</div>
+	  <div class="clear"></div>
+	</div>
+	{assign var=n value=billing_city-$bltID}
+	<div class="crm-section {$form.$n.name}-section">
+	  <div class="label">{$form.$n.label}</div>
+	  <div class="content">{$form.$n.html}</div>
+	  <div class="clear"></div>
+	</div>
+	{assign var=n value=billing_country_id-$bltID}
+	<div class="crm-section {$form.$n.name}-section">
+	  <div class="label">{$form.$n.label}</div>
+	  <div class="content">{$form.$n.html|crmReplace:class:big}</div>
+	  <div class="clear"></div>
+	</div>
+	{assign var=n value=billing_state_province_id-$bltID}
+	<div class="crm-section {$form.$n.name}-section" id="dd_billing_block_state_province_id">
+	  <div class="label">{$form.$n.label}</div>
+	  <div class="content">{$form.$n.html|crmReplace:class:big}</div>
+	  <div class="clear"></div>
+	</div>
+	{assign var=n value=billing_postal_code-$bltID}
+	<div class="crm-section {$form.$n.name}-section">
+	  <div class="label">{$form.$n.label}</div>
+	  <div class="content">{$form.$n.html}</div>
+	  <div class="clear"></div>
+	</div>
+    </div>
+    </fieldset>
+  </div>
+{else}  
+  {include file="CRM/Core/BillingBlock.tpl"}
+{/if}
+
+<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>

--- a/templates/CRM/Contribute/Form/UpdateSubscription.tpl
+++ b/templates/CRM/Contribute/Form/UpdateSubscription.tpl
@@ -1,3 +1,4 @@
+<!-- Customised Civi File .tpl file invoked: ukdirectdebit/templates/CRM/Contribute/Form/UpdateSubscription.tpl. Call via form.tpl if we have a form in the page. -->
 {*
  +--------------------------------------------------------------------+
  | CiviCRM version 4.4                                                |
@@ -43,7 +44,11 @@
     </tr>
     <tr>
       <td class="label">{$form.start_date.label}</td><td>
-        <span class="value">{include file="CRM/common/jcalendar.tpl" elementName=start_date}</span></td>
+	{if $membership}
+        {$form.start_date.html}
+	{else}
+	<span class="value">{include file="CRM/common/jcalendar.tpl" elementName=start_date}</span>
+	{/if}</td>
     </tr>
     <tr>
       <td class="label">{$form.end_date.label}</td><td>

--- a/templates/CRM/Contribute/Page/ContributionRecur.extra.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecur.extra.tpl
@@ -2,7 +2,6 @@
     <script type="text/javascript">
       CRM.$(function($) {
 	var smartDetails = {/literal}{$contributionRecurDetails}{literal};
-	console.log(smartDetails);
 	if (!CRM.$.isEmptyObject(smartDetails)) {
 	  var targetHtml = '<h3>View Smart Debit Payment</h3><table class = "crm-info-panel direct-debit">';
 	  for (var k in smartDetails) {

--- a/templates/CRM/Contribute/Page/ContributionRecur.extra.tpl
+++ b/templates/CRM/Contribute/Page/ContributionRecur.extra.tpl
@@ -1,0 +1,18 @@
+{literal}
+    <script type="text/javascript">
+      CRM.$(function($) {
+	var smartDetails = {/literal}{$contributionRecurDetails}{literal};
+	console.log(smartDetails);
+	if (!CRM.$.isEmptyObject(smartDetails)) {
+	  var targetHtml = '<h3>View Smart Debit Payment</h3><table class = "crm-info-panel direct-debit">';
+	  for (var k in smartDetails) {
+	    if (smartDetails.hasOwnProperty(k)) {
+	      targetHtml = targetHtml.concat('<tr><td class="label">'+k+'</td><td>' +smartDetails[k] + '</td></tr>');
+	    }
+	  }
+	  targetHtml = targetHtml.concat('</table>');
+	  CRM.$( ".crm-info-panel" ).after( targetHtml );
+	}
+      });
+    </script>
+{/literal}

--- a/templates/CRM/DirectDebit/Form/Newdd.tpl
+++ b/templates/CRM/DirectDebit/Form/Newdd.tpl
@@ -1,0 +1,151 @@
+<div class="crm-block crm-form-block crm-contribution-form-block">
+  <div class="crm-section {$form.first_name.name}-section">
+    <div class="label">{$form.first_name.label}</div>
+    <div class="content">{$form.first_name.html}</div>
+    <div class="clear"></div>
+  </div>
+  <div class="crm-section {$form.last_name.name}-section">
+    <div class="label">{$form.last_name.label}</div>
+    <div class="content">{$form.last_name.html}</div>
+    <div class="clear"></div>
+  </div>
+  <div class="crm-section {$form.amount.name}-section">
+    <div class="label">{$form.amount.label}</div>
+    <div class="content">{$form.amount.html}</div>
+    <div class="clear"></div>
+  </div>
+  {assign var=n value=email-$bltID}
+  <div class="crm-section {$form.$n.name}-section">
+    <div class="label">{$form.$n.label}</div>
+    <div class="content">{$form.$n.html}</div>
+    <div class="clear"></div>
+  </div>  
+  <div class="crm-section {$form.ddi_reference.name}-section">
+    <div class="label">{$form.ddi_reference.label}</div>
+    <div class="content">{$form.ddi_reference.html}</div>
+    <div class="clear"></div>
+  </div>
+    
+  <div id="payment_information">
+    <fieldset class="billing_mode-group {if $paymentProcessor.payment_type & 2}direct_debit_info-group{else}credit_card_info-group{/if}">
+      <legend>
+	{ts}Direct Debit Information{/ts}
+      </legend>
+	{ts}<p>All the normal Direct Debit safeguards and guarantees apply.
+No changes in the amount, date or frequency to be debited can be made without notifying you at least 10 working days in advance of your account being debited.
+In the event of any error, you are entitled to an immediate refund from your bank or building society.
+You have the right to cancel a Direct Debit Instruction at any time simply by writing to your bank or building society, with a copy to us.</p>
+<p>In order to set up your Direct Debit Instruction on-line you will need to provide the following information through the setting up procedure (your cheque book contains all the bank details that you require):</p>
+<p>Bank or Building Society name and account number, sort code and branch address.</p>
+<ul>
+<li>If you are not the account holder, a paper Direct Debit Instruction will be sent for completion. Please click to end</li>
+<li>If this is a personal account continue with the set-up procedure</li>
+<li>If it is a business account and more than one person is required to authorise debits on this account, a paper Direct Debit Instruction will be sent to the Payers for completion.</li>
+</ul>
+
+<p>Alternatively you can print off your on-screen Direct Debit Instruction and post it to us: <b>{$company_address.company_name}</b>, {if ($company_address.address1 != '')} {$company_address.address1}, {/if}{if ($company_address.address2 != '')} {$company_address.address2}, {/if}{if ($company_address.address3 != '')} {$company_address.address3}, {/if}{if ($company_address.address4 != '')} {$company_address.address4}, {/if}{if ($company_address.town != '')} {$company_address.town}, {/if}{if ($company_address.county != '')} {$company_address.county}, {/if}{if ($company_address.postcode != '')} {$company_address.postcode}{/if}. If you are unable to print please contact us on {$telephoneNumber} (tel no) and we will post you a paper Direct Debit Instruction.
+If you do not wish to proceed any further please <a href="/">click here</a> to end.</p>
+<p>The details of your Direct Debit Instruction will be sent to you within 3 working days or no later than 10 working days before the first collection.</p>{/ts}
+
+
+    <div class="crm-section billing_mode-section direct_debit_info-section">
+      <div class="crm-section {$form.account_holder.name}-section">
+	  <div class="label">{$form.account_holder.label}</div>
+	  <div class="content">{$form.account_holder.html}</div>
+	  <div class="clear"></div>
+      </div>
+      <div class="crm-section {$form.bank_identification_number.name}-section">
+	  <div class="label">{$form.bank_identification_number.label}</div>
+	  <div class="content">{$form.bank_identification_number.html}</div>
+	  <div class="clear"></div>
+      </div>
+      <div class="crm-section {$form.bank_account_number.name}-section">
+	  <div class="label">{$form.bank_account_number.label}</div>
+	  <div class="content">{$form.bank_account_number.html}</div>
+	  <div class="clear"></div>
+      </div>
+      <div class="crm-section {$form.bank_name.name}-section">
+	  <div class="label">{$form.bank_name.label}</div>
+	  <div class="content">{$form.bank_name.html}</div>
+	  <div class="clear"></div>
+      </div>
+
+      <div class="crm-section {$form.preferred_collection_day.name}-section">
+	  <div class="label">{$form.preferred_collection_day.label}</div>
+	  <div class="content">{$form.preferred_collection_day.html}</div>
+	  <div class="clear"></div>
+      </div>
+      <div class="crm-section {$form.confirmation_method.name}-section">
+	  <div class="label">{$form.confirmation_method.label}</div>
+	  <div class="content">{$form.confirmation_method.html}</div>
+	  <div class="clear"></div>
+      </div>
+      <div class="crm-section {$form.payer_confirmation.name}-section">
+	  <div class="label">{$form.payer_confirmation.label}</div>
+	  <div class="content">{$form.payer_confirmation.html}</div>
+	  <div class="clear"></div>
+      </div>
+
+    </div>
+  </fieldset>
+  <fieldset class="billing_name_address-group">
+    <legend>{ts}Billing Name and Address{/ts}</legend>
+    <div class="crm-section billing_name_address-section">
+	<div class="crm-section billingNameInfo-section">
+	  <div class="content description">
+	       {ts}Enter the name of the account holder, and the corresponding billing address.{/ts}
+	  </div>
+	</div>
+	<div class="crm-section {$form.billing_first_name.name}-section">
+	  <div class="label">{$form.billing_first_name.label}</div>
+	  <div class="content">{$form.billing_first_name.html}</div>
+	  <div class="clear"></div>
+	</div>
+	<div class="crm-section {$form.billing_middle_name.name}-section">
+	  <div class="label">{$form.billing_middle_name.label}</div>
+	  <div class="content">{$form.billing_middle_name.html}</div>
+	  <div class="clear"></div>
+	</div>
+	<div class="crm-section {$form.billing_last_name.name}-section">
+	  <div class="label">{$form.billing_last_name.label}</div>
+	  <div class="content">{$form.billing_last_name.html}</div>
+	  <div class="clear"></div>
+	</div>
+	{assign var=n value=billing_street_address-$bltID}
+	<div class="crm-section {$form.$n.name}-section">
+	  <div class="label">{$form.$n.label}</div>
+	  <div class="content">{$form.$n.html}</div>
+	  <div class="clear"></div>
+	</div>
+	{assign var=n value=billing_city-$bltID}
+	<div class="crm-section {$form.$n.name}-section">
+	  <div class="label">{$form.$n.label}</div>
+	  <div class="content">{$form.$n.html}</div>
+	  <div class="clear"></div>
+	</div>
+	{assign var=n value=billing_country_id-$bltID}
+	<div class="crm-section {$form.$n.name}-section">
+	  <div class="label">{$form.$n.label}</div>
+	  <div class="content">{$form.$n.html|crmReplace:class:big}</div>
+	  <div class="clear"></div>
+	</div>
+	{assign var=n value=billing_state_province_id-$bltID}
+	<div class="crm-section {$form.$n.name}-section" id="dd_billing_block_state_province_id">
+	  <div class="label">{$form.$n.label}</div>
+	  <div class="content">{$form.$n.html|crmReplace:class:big}</div>
+	  <div class="clear"></div>
+	</div>
+	{assign var=n value=billing_postal_code-$bltID}
+	<div class="crm-section {$form.$n.name}-section">
+	  <div class="label">{$form.$n.label}</div>
+	  <div class="content">{$form.$n.html}</div>
+	  <div class="clear"></div>
+	</div>
+    </div>
+    </fieldset>
+  </div>
+</div>
+
+<div id="crm-submit-buttons" class="crm-submit-buttons">
+{include file="CRM/common/formButtons.tpl" location="bottom"}
+</div>

--- a/templates/CRM/DirectDebit/Form/Newdonation.tpl
+++ b/templates/CRM/DirectDebit/Form/Newdonation.tpl
@@ -19,7 +19,17 @@
     <div class="label">{$form.$n.label}</div>
     <div class="content">{$form.$n.html}</div>
     <div class="clear"></div>
-  </div>  
+  </div>    
+  <div class="crm-section {$form.frequency_unit.name}-section">
+    <div class="label">{$form.frequency_unit.label}</div>
+    <div class="content">{$form.frequency_unit.html}</div>
+    <div class="clear"></div>
+  </div>
+  <div class="crm-section {$form.financial_type_id.name}-section">
+    <div class="label">{$form.financial_type_id.label}</div>
+    <div class="content">{$form.financial_type_id.html}</div>
+    <div class="clear"></div>
+  </div>
   <div class="crm-section {$form.ddi_reference.name}-section">
     <div class="label">{$form.ddi_reference.label}</div>
     <div class="content">{$form.ddi_reference.html}</div>
@@ -59,7 +69,6 @@ If you do not wish to proceed any further please <a href="/">click here</a> to e
 	  <div class="label">{$form.bank_identification_number.label}</div>
 	  <div class="content">{$form.bank_identification_number.html}
 	  <div class="description">{ts}Sort Code – either 111111 or 11-11-11 format accepted.{/ts}</div></div>
-	  </div>
 	  <div class="clear"></div>
       </div>
       <div class="crm-section {$form.bank_account_number.name}-section">

--- a/uk_direct_debit.php
+++ b/uk_direct_debit.php
@@ -987,3 +987,17 @@ function uk_direct_debit_civicrm_navigationMenu( &$params ) {
                                             )
                         );
 }
+
+function uk_direct_debit_civicrm_links( $op, $objectName, $objectId, &$links, &$mask, &$values ) {
+  if ($objectName == 'Membership') {
+    $cid = $values['cid'];
+    $id = $values['id'];
+    $links[] = array(
+              'name' => ts('Setup Direct Debit'),
+              'title' => ts('Setup Direct Debit'),
+              'url' => 'civicrm/directdebit/new',
+              'qs' => "action=add&reset=1&cid=$cid&id=$id"
+            );
+    
+  }  
+}

--- a/uk_direct_debit.php
+++ b/uk_direct_debit.php
@@ -658,6 +658,15 @@ function uk_direct_debit_civicrm_buildForm( $formName, &$form ) {
     if ($formName == 'CRM_Contribute_Form_UpdateSubscription') {
       $paymentProcessor = $form->_paymentProcessor;
       if($paymentProcessor['payment_processor_type'] == 'Smart Debit') {
+	$recurID = $form->getVar('_crid');
+	$columnExists = CRM_Core_DAO::checkFieldExists('civicrm_contribution_recur', 'membership_id');
+	$linkedMembership = FALSE;
+	if($columnExists) {
+	  $membershipID = CRM_Core_DAO::singleValueQuery('SELECT membership_id FROM civicrm_contribution_recur WHERE id = %1', array(1=>array($recurID, 'Int')));
+	  if ($membershipID) {
+	    $linkedMembership = TRUE;
+	  }
+	}
         $form->removeElement('installments');
         $frequencyType = array(
           'D'  => 'Daily',
@@ -666,7 +675,7 @@ function uk_direct_debit_civicrm_buildForm( $formName, &$form ) {
           'Y'  => 'Annually'
         );
 
-        $form->addElement('select', 'frequency_unit', ts('Frequency'),
+	$form->addElement('select', 'frequency_unit', ts('Frequency'),
             array('' => ts('- select -')) + $frequencyType
         );
         $form->addDate('start_date', ts('Start Date'), FALSE, array('formatType' => 'custom'));
@@ -687,6 +696,12 @@ function uk_direct_debit_civicrm_buildForm( $formName, &$form ) {
         list($defaults['start_date'], $defaults['start_date_time']) = CRM_Utils_Date::setDateDefaults($startDate, NULL);
         $defaults['frequency_unit'] = array_search($frequencyUnit, $frequencyUnits);
         $form->setDefaults($defaults);
+	if ($linkedMembership) {
+	  $e =& $form->getElement('frequency_unit');
+	  $e->freeze();
+	  $e =& $form->getElement('start_date');
+	  $e->freeze();
+	}
     }
   }
 
@@ -992,12 +1007,58 @@ function uk_direct_debit_civicrm_links( $op, $objectName, $objectId, &$links, &$
   if ($objectName == 'Membership') {
     $cid = $values['cid'];
     $id = $values['id'];
+    $name   = ts('Setup Direct Debit');
+    $title  = ts('Setup Direct Debit');
+    $url    = 'civicrm/directdebit/new';
+    $qs	    = "action=add&reset=1&cid=$cid&id=$id";
+    $columnExists = CRM_Core_DAO::checkFieldExists('civicrm_contribution_recur', 'membership_id');
+    if($columnExists) {
+      $recurID = CRM_Core_DAO::singleValueQuery('SELECT id FROM civicrm_contribution_recur WHERE membership_id = %1', array(1=>array($id, 'Int')));
+      if (!empty($recurID)) {
+	$name   = ts('View Direct Debit');
+	$title  = ts('View Direct Debit');
+	$url    = 'civicrm/contact/view/contributionrecur';
+	$qs	= "reset=1&id=$recurID&cid=$cid";
+      }
+    }
     $links[] = array(
-              'name' => ts('Setup Direct Debit'),
-              'title' => ts('Setup Direct Debit'),
-              'url' => 'civicrm/directdebit/new',
-              'qs' => "action=add&reset=1&cid=$cid&id=$id"
+              'name' => $name,
+              'title' => $title,
+              'url' => $url,
+              'qs' => $qs
             );
     
   }  
+}
+
+function uk_direct_debit_civicrm_pageRun(&$page) {
+  $pageName = $page->getVar('_name');
+  if ($pageName == 'CRM_Contribute_Page_ContributionRecur') {
+      $session = CRM_Core_Session::singleton();
+      $contactID = $session->get('userID');
+    if (CRM_Contact_BAO_Contact_Permission::allow($contactID, CRM_Core_Permission::EDIT)) {
+      $recurID = $page->getVar('_id');
+      $query = "
+	SELECT cr.trxn_id FROM civicrm_contribution_recur cr
+	INNER JOIN civicrm_payment_processor cpp ON cpp.id = cr.payment_processor_id
+	INNER JOIN civicrm_payment_processor_type cppt ON cppt.id = cpp.payment_processor_type_id
+	WHERE cppt.name = %1 AND cr.id = %2";
+
+      $queryParams = array (
+	1 => array('Smart Debit', 'String'),
+	2 => array($recurID, 'Int'),
+      );
+
+      $smartDebitReference = CRM_Core_DAO::singleValueQuery($query, $queryParams);
+      $contributionRecurDetails = array();
+      if (!empty($smartDebitReference)) {
+	$smartDebitResponse = CRM_DirectDebit_Form_SyncSd::getSmartDebitPayments($smartDebitReference);
+	foreach ($smartDebitResponse[0] as $key => $value) {
+	  $contributionRecurDetails[$key] = $value;
+	}
+      $contributionRecurDetails = json_encode($contributionRecurDetails);
+      $page->assign('contributionRecurDetails', $contributionRecurDetails);
+      }
+    }
+  }
 }

--- a/xml/Menu/DirectDebit.xml
+++ b/xml/Menu/DirectDebit.xml
@@ -73,5 +73,14 @@
     <page_type>0</page_type>
     <component>Contact</component>
   </item>
+  <item>
+    <path>civicrm/directdebit/new</path>
+    <title>Setup A New Direct Debit</title>
+    <path_arguments>reset=1</path_arguments>
+    <page_callback>CRM_DirectDebit_Form_Newdd</page_callback>
+    <access_arguments>administer CiviCRM</access_arguments>
+    <page_type>0</page_type>
+    <component>Contact</component>
+  </item>
 </menu>
 

--- a/xml/Menu/DirectDebit.xml
+++ b/xml/Menu/DirectDebit.xml
@@ -82,5 +82,14 @@
     <page_type>0</page_type>
     <component>Contact</component>
   </item>
+    <item>
+    <path>civicrm/directdebit/newdonation</path>
+    <title>Setup A New Donation Direct Debit</title>
+    <path_arguments>reset=1</path_arguments>
+    <page_callback>CRM_DirectDebit_Form_Newdonation</page_callback>
+    <access_arguments>administer CiviCRM</access_arguments>
+    <page_type>0</page_type>
+    <component>Contact</component>
+  </item>
 </menu>
 


### PR DESCRIPTION
1. New link called 'Setup Direct Debit' in contact membership tab
2. New form wher user enter direct debit details
3. Validatation check before submission to smart debit
4. After successful submission of smart debit, check recurring against membership
5. If no recurring, create new recur, update recur with membership
6. Display direct debit details in view recurring only if persion viewing has edit permission
7. Froze frequecny and start date in  edit recurring if recurring is linked to membership
8. Changed new link name to 'View Direct Debit' after done offline direct debit which will point to view recurring with direct debit details in it
9. Offline Donation Direct Debit setup
10. Notice fixes on supplementary address 1 and 2 and county 
11. Update Billing address of recurring contirbution
12. Edit recurring contribution amount validation -- if it is linked to membership, only allow higher than membership amount