### PR TITLE
Smart debit import - use the payment amount from smart debit

### DIFF
--- a/CRM/DirectDebit/Form/Auddis.php
+++ b/CRM/DirectDebit/Form/Auddis.php
@@ -100,8 +100,9 @@ class CRM_DirectDebit_Form_Auddis extends CRM_Core_Form {
 
     if(!empty($validIds)){
     $validIdsString = implode(',', $validIds);
-    $sql = "SELECT ctrc.id contribution_recur_id ,ctrc.contact_id , cont.display_name ,ctrc.start_date , ctrc.amount, ctrc.trxn_id , ctrc.frequency_unit, ctrc.payment_instrument_id, ctrc.contribution_status_id
+    $sql = "SELECT ctrc.id contribution_recur_id ,ctrc.contact_id , cont.display_name ,ctrc.start_date , sdpayments.amount, ctrc.trxn_id , ctrc.frequency_unit, ctrc.payment_instrument_id, ctrc.contribution_status_id
       FROM civicrm_contribution_recur ctrc
+      INNER JOIN veda_civicrm_smartdebit_import sdpayments ON sdpayments.transaction_id = ctrc.trxn_id
       INNER JOIN civicrm_contact cont ON (ctrc.contact_id = cont.id)
       WHERE ctrc.trxn_id IN ($validIdsString)";
 

--- a/CRM/DirectDebit/Form/Confirm.php
+++ b/CRM/DirectDebit/Form/Confirm.php
@@ -287,7 +287,7 @@ class CRM_DirectDebit_Form_Confirm extends CRM_Core_Form {
       $params = array( 1 => array( $smartDebitRecord, 'String' ) );
       $dao = CRM_Core_DAO::executeQuery( $sql, $params);
 
-      $selectQuery  = "SELECT `receive_date` as receive_date FROM `veda_civicrm_smartdebit_import` WHERE `transaction_id` = '{$smartDebitRecord}'";
+      $selectQuery  = "SELECT `receive_date` as receive_date, `amount` as amount FROM `veda_civicrm_smartdebit_import` WHERE `transaction_id` = '{$smartDebitRecord}'";
       $daoSelect    = CRM_Core_DAO::executeQuery($selectQuery);
       $daoSelect->fetch();
 
@@ -306,7 +306,7 @@ class CRM_DirectDebit_Form_Confirm extends CRM_Core_Form {
           'version'                => 3,
           'contact_id'             => $dao->contact_id,
           'contribution_recur_id'  => $dao->contribution_recur_id,
-          'total_amount'           => $dao->amount,
+          'total_amount'           => $daoSelect->amount,
           'invoice_id'             => md5(uniqid(rand(), TRUE )),
           'trxn_id'                => $smartDebitRecord.'/'.CRM_Utils_Date::processDate($receiveDate),
           'financial_type_id'      => $financialTypeID,


### PR DESCRIPTION
Smart debit import - use the payment amount from smart debit instead of the amount from recurring contribution, when creating contribution records during import