### PR TITLE
Fix for issue #48

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -174,8 +174,8 @@
     {/if}
     
     {if $onbehalfProfile}
-      <div class="crm-group onBehalf_display-group">
-         {include file="CRM/UF/Form/Block.tpl" fields=$onbehalfProfile}
+      <div class="crm-group onBehalf_display-group label-left crm-profile-view">
+         {include file="CRM/UF/Form/Block.tpl" fields=$onbehalfProfile prefix='onbehalf'}
          <div class="crm-section organization_email-section">
             <div class="label">{ts}Organization Email{/ts}</div>
             <div class="content">{$onBehalfEmail}</div>

--- a/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
@@ -237,8 +237,8 @@
     {/if}
 
     {if $onbehalfProfile}
-      <div class="crm-group onBehalf_display-group">
-         {include file="CRM/UF/Form/Block.tpl" fields=$onbehalfProfile}
+      <div class="crm-group onBehalf_display-group label-left crm-profile-view">
+         {include file="CRM/UF/Form/Block.tpl" fields=$onbehalfProfile prefix='onbehalf'}
          <div class="crm-section organization_email-section">
             <div class="label">{ts}Organization Email{/ts}</div>
             <div class="content">{$onBehalfEmail}</div>


### PR DESCRIPTION
Prefixes were missing from the 'On behalf of' profiles in the Confirm and Thank You templates.